### PR TITLE
fix: skinRef's height increase when resize

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -464,8 +464,11 @@ async function adjustUI() {
 <style scoped>
 .container.wide-ui {
   display: grid;
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  right: 5px;
+  bottom: 5px;
   grid-template-columns: 40% 60%;
   grid-template-rows: calc(100% - 60px) 60px;
   grid-template-areas: "section controls" "footer footer";


### PR DESCRIPTION
当选择宽UI时，窗口发生resize，skinRef的高度会增长，发现如果在父高度为auto（未设置的情况下），设置的百分比不起效，将设置他的父元素设置为绝对定位，从而使百分比起效